### PR TITLE
Add "emoji" field to all commit types

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -1,37 +1,48 @@
 {
   "types": {
     "feat": {
-      "description": "✨  A new feature"
+      "description": "✨  A new feature",
+      "emoji": "✨"
     },
     "fix": {
-      "description": "🐛  A bug fix"
+      "description": "🐛  A bug fix",
+      "emoji": "🐛"
     },
     "docs": {
-      "description": "📖  Documentation only changes"
+      "description": "📖  Documentation only changes",
+      "emoji": "📖"
     },
     "style": {
-      "description": "💎  Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"
+      "description": "💎  Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)",
+      "emoji": "💎"
     },
     "refactor": {
-      "description": "📦  A code change that neither fixes a bug nor adds a feature"
+      "description": "📦  A code change that neither fixes a bug nor adds a feature",
+      "emoji": "📦"
     },
     "perf": {
-      "description": "🚀  A code change that improves performance"
+      "description": "🚀  A code change that improves performance",
+      "emoji": "🚀"
     },
     "test": {
-      "description": "🚨  Adding missing tests or correcting existing tests"
+      "description": "🚨  Adding missing tests or correcting existing tests",
+      "emoji": "🚨"
     },
     "build": {
-      "description": "👷  Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)"
+      "description": "👷  Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)",
+      "emoji": "👷"
     },
     "ci": {
-      "description": "💻  Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)"
+      "description": "💻  Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)",
+      "emoji": "💻"
     },
     "chore": {
-      "description": "🎫  Other changes that don't modify src or test files"
+      "description": "🎫  Other changes that don't modify src or test files",
+      "emoji": "🎫"
     },
     "revert": {
-      "description": "🔙  Reverts a previous commit"
+      "description": "🔙  Reverts a previous commit",
+      "emoji": "🔙"
     }
   }
 }


### PR DESCRIPTION
Solves the issue to not add the emoji on the commit message when using commitizen with `cz-conventional-changelog-emoji` [plugin](https://github.com/ellerbrock/cz-conventional-changelog-emoji)